### PR TITLE
Add builtin equivalent for _flags_itemInList

### DIFF
--- a/src/shflags
+++ b/src/shflags
@@ -479,14 +479,20 @@ _flags_itemInList() {
   _flags_str_=$1
   shift
 
-  echo " ${*:-} " |grep " ${_flags_str_} " >/dev/null
+  if _flags_useBuiltin; then
+    _flags_params_=" ${*:-} "
+    test "${_flags_params_#*" ${_flags_str_} "}" != "${_flags_params_}"
+  else
+    echo " ${*:-} " |grep " ${_flags_str_} " >/dev/null
+  fi
+
   if [ $? -eq 0 ]; then
     flags_return=${FLAGS_TRUE}
   else
     flags_return=${FLAGS_FALSE}
   fi
 
-  unset _flags_str_
+  unset _flags_str_ _flags_params_
   return ${flags_return}
 }
 


### PR DESCRIPTION
Speeds up shflags_test_parsing by 13%:
Before:
./shflags_test_parsing.sh  0.27s user 0.21s system 10% cpu 4.727 total
After:
./shflags_test_parsing.sh  0.18s user 0.18s system 8% cpu 4.176 total